### PR TITLE
Fix test problem in build-in-docker, recompile each run

### DIFF
--- a/minitwit/Dockerfile_build
+++ b/minitwit/Dockerfile_build
@@ -1,6 +1,4 @@
 FROM maven:3.8.4-openjdk-17-slim
-VOLUME [ "/out" ]
-COPY . /usr/src/minitwit
-WORKDIR /usr/src/minitwit
-RUN ./control.sh build
-ENTRYPOINT [ "cp", "/usr/src/minitwit/minitwit.jar", "/out/minitwit.jar" ]
+VOLUME [ "/out", "/src" ]
+WORKDIR /src
+ENTRYPOINT [ "./control.sh", "build" ]

--- a/minitwit/Dockerfile_build
+++ b/minitwit/Dockerfile_build
@@ -1,4 +1,6 @@
 FROM maven:3.8.4-openjdk-17-slim
-VOLUME [ "/out", "/src" ]
-WORKDIR /src
-ENTRYPOINT [ "./control.sh", "build" ]
+VOLUME [ "/out" ]
+COPY . /usr/src/minitwit
+WORKDIR /usr/src/minitwit
+RUN ./control.sh build
+ENTRYPOINT [ "cp", "/usr/src/minitwit/minitwit.jar", "/out/minitwit.jar" ]

--- a/minitwit/control.sh
+++ b/minitwit/control.sh
@@ -21,11 +21,11 @@ function build {
 
 function build-in-docker {
     images=$( sudo docker images | grep minitwit-builder )
-    if [ -z $images ]
+    if [ -z "$images" ]
     then
         docker build --tag minitwit-builder -f ./Dockerfile_build .
     fi
-    docker run --volume /tmp/minitwit:/out minitwit-builder
+    docker run --volume "$PWD":/src --volume /tmp/minitwit:/out minitwit-builder
     cp /tmp/minitwit/minitwit.jar ./
 }
 

--- a/minitwit/control.sh
+++ b/minitwit/control.sh
@@ -20,13 +20,43 @@ function build {
 }
 
 function build-in-docker {
+    # Check for existing minitwit-builder and delete if found
     images=$( sudo docker images | grep minitwit-builder )
-    if [ -z "$images" ]
+    if [ -n "$images" ]
     then
-        docker build --tag minitwit-builder -f ./Dockerfile_build .
+        echo "Old minitwit-builder already exists, attempting to delete it..."
+        docker rmi minitwit-builder -f 
     fi
-    docker run --volume "$PWD":/src --volume /tmp/minitwit:/out minitwit-builder
+
+    # Build java project and store it in the image
+    docker build --tag minitwit-builder -f ./Dockerfile_build .
+    success=$?
+
+    # Notify user if something fails, return exit code
+    if [ $success != 0 ] ;
+    then
+        echo ""
+        echo "Done with build errors"
+        exit $success
+    fi
+
+    # Run only copies final jar file to container /out directory
+    docker run --rm --volume /tmp/minitwit:/out minitwit-builder
+    success=$?
     cp /tmp/minitwit/minitwit.jar ./
+
+    # Clean up
+    docker rmi minitwit-builder -f
+
+    # Echo final status message
+    echo ""
+    if [ $success ]
+    then
+        echo "Done!"
+    else
+        echo "Done with during java build errors"
+        exit $success
+    fi
 }
 
 if [ "$1" = "init-and-start" ]


### PR DESCRIPTION
Script now removes the builder image and tries to indicate if the build was successful.
Closes #44 