### PR TITLE
updated velocity to version 3.1

### DIFF
--- a/minitwit/pom.xml
+++ b/minitwit/pom.xml
@@ -66,10 +66,11 @@
             <version>2.3</version>
         </dependency>
 
+
         <dependency>
-            <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity-tools</artifactId>
-            <version>2.0</version>
+          <groupId>org.apache.velocity.tools</groupId>
+          <artifactId>velocity-tools-view</artifactId>
+          <version>3.1</version>
         </dependency>
 
         <dependency>
@@ -83,5 +84,6 @@
             <artifactId>jgravatar</artifactId>
             <version>1.2</version>
         </dependency>
+
     </dependencies>
 </project>


### PR DESCRIPTION
Velocity Engine is already 2.3
Velocity Tools are now 3.1

using artifact velocity-tools-view (took ages to find this) allows using DateTool (essentially velocity.tools)