### PR TITLE
Add /latest API endpoint

### DIFF
--- a/minitwit/src/main/java/WebApplication.java
+++ b/minitwit/src/main/java/WebApplication.java
@@ -212,8 +212,8 @@ public class WebApplication {
     }
 
     public static void updateLatest(Request request) {
-        String tryLatest = request.params("latest");
-        LATEST = Integer.parseInt(tryLatest);
+        String latest = request.params("latest");
+        LATEST = Integer.parseInt(latest);
     }
 
     public static Route add_message = (Request request, Response response)  -> {

--- a/minitwit/src/main/java/WebApplication.java
+++ b/minitwit/src/main/java/WebApplication.java
@@ -65,11 +65,15 @@ public class WebApplication {
 
         // Sim API
         public static final String SIM_MESSAGES = "/msgs";
+        public static final String SIM_LATEST = "/latest";
     }
 
     public static int PER_PAGE = 30;
 
     public static Gson gson = new Gson();
+
+    // The ID of the latest request made by the simulator
+    public static int LATEST = 0;
 
     private static final Gravatar gravatar = new Gravatar()
             .setSize(48)
@@ -102,6 +106,7 @@ public class WebApplication {
             before("/*", protectEndpoint);
 
             get(URLS.SIM_MESSAGES, WebApplication.serveSimMsgs, gson::toJson);
+            get(URLS.SIM_LATEST, WebApplication.serveSimLatest, gson::toJson);
         });
     }
 
@@ -204,6 +209,11 @@ public class WebApplication {
     // Used by timeline.vm to display user's gravatar
     public static String getGravatarURL(String email) {
         return gravatar.getUrl(email);
+    }
+
+    public static void updateLatest(Request request) {
+        String tryLatest = request.params("latest");
+        LATEST = Integer.parseInt(tryLatest);
     }
 
     public static Route add_message = (Request request, Response response)  -> {
@@ -546,6 +556,9 @@ public class WebApplication {
     };
 
     public static Route serveSimMsgs = (Request request, Response response) -> {
+        // Update LATEST static variable
+        updateLatest(request);
+
         var messages = getMessages();
         var filteredMessages = messages.stream().map((message) -> {
             return Map.ofEntries(
@@ -555,5 +568,9 @@ public class WebApplication {
             );
         });
         return filteredMessages.toList();
+    };
+
+    public static Route serveSimLatest = (Request request, Response response) -> {
+        return new HashMap<>().put("latest", LATEST);
     };
 }

--- a/minitwit/src/main/java/WebApplication.java
+++ b/minitwit/src/main/java/WebApplication.java
@@ -212,7 +212,7 @@ public class WebApplication {
     }
 
     public static void updateLatest(Request request) {
-        String latest = request.params("latest");
+        String latest = request.queryParams("latest");
         LATEST = Integer.parseInt(latest);
     }
 

--- a/minitwit/src/main/java/WebApplication.java
+++ b/minitwit/src/main/java/WebApplication.java
@@ -571,6 +571,8 @@ public class WebApplication {
     };
 
     public static Route serveSimLatest = (Request request, Response response) -> {
-        return new HashMap<>().put("latest", LATEST);
+        Map<String, Integer> map = new HashMap<>();
+        map.put("latest", LATEST);
+        return map;
     };
 }

--- a/minitwit/src/main/java/WebApplication.java
+++ b/minitwit/src/main/java/WebApplication.java
@@ -213,7 +213,9 @@ public class WebApplication {
 
     public static void updateLatest(Request request) {
         String latest = request.queryParams("latest");
-        LATEST = Integer.parseInt(latest);
+        if (latest != null) {
+            LATEST = Integer.parseInt(latest);
+        }
     }
 
     public static Route add_message = (Request request, Response response)  -> {


### PR DESCRIPTION
Closes #41 

Every other API endpoint we make needs to call `updateLatest(request)` - the same is being done in the Python version (`minitwit_sim_api.py`).

Unfortunately I cannot test whether it truly works until the /register endpoint is up and running, due to the tests in `minitwit_sim_api_test.py` being dependent on it.