### PR TITLE
Add slf4j logger library for logs

### DIFF
--- a/minitwit/pom.xml
+++ b/minitwit/pom.xml
@@ -147,5 +147,17 @@
             <artifactId>simpleclient_httpserver</artifactId>
             <version>0.15.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.36</version>
+        </dependency>
     </dependencies>
 </project>

--- a/minitwit/src/main/java/WebApplication.java
+++ b/minitwit/src/main/java/WebApplication.java
@@ -122,8 +122,9 @@ public class WebApplication {
 
         after("/*", (req, res) -> {
             long startTime = req.attribute("startTime");
+            long time = -1;
             if (startTime != 0) {
-                long time = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
+                time = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
                 metrics.observeRequestTime(
                         time,
                         req.uri().startsWith("/api")
@@ -133,7 +134,13 @@ public class WebApplication {
                 );
             }
 
-            logger.info("t={} status={} method={} {}", LocalDateTime.now(), res.status(), req.requestMethod(), req.uri() );
+            logger.info("t={} d={} status={} method={} remote_ip={} {}",
+                    LocalDateTime.now(),
+                    time,
+                    res.status(),
+                    req.requestMethod(),
+                    req.ip(),
+                    req.uri() );
         });
 
         //before("/metrics", protectEndpoint("Basic asdf"));

--- a/minitwit/src/main/java/WebApplication.java
+++ b/minitwit/src/main/java/WebApplication.java
@@ -946,7 +946,6 @@ public class WebApplication {
     };
 
     public static Route serveMetrics = (Request request, Response response) -> {
-        if (true)throw new Exception("Ew");
         return metrics.metrics();
     };
 

--- a/minitwit/src/main/java/WebApplication.java
+++ b/minitwit/src/main/java/WebApplication.java
@@ -84,7 +84,7 @@ public class WebApplication {
     public static int PER_PAGE = 30;
 
     public static Gson gson = new Gson();
-    public static Logger logger = LoggerFactory.getLogger("Minitwit");
+    public static final Logger logger = LoggerFactory.getLogger("Minitwit");
 
     public static PrometheusMetrics metrics = new PrometheusMetrics();
 

--- a/minitwit/src/main/java/WebApplication.java
+++ b/minitwit/src/main/java/WebApplication.java
@@ -12,6 +12,8 @@ import org.springframework.security.crypto.bcrypt.BCrypt;
 import spark.*;
 import static spark.Spark.*;
 import org.apache.velocity.Template;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.StringWriter;
 import java.sql.Connection;
@@ -82,6 +84,7 @@ public class WebApplication {
     public static int PER_PAGE = 30;
 
     public static Gson gson = new Gson();
+    public static Logger logger = LoggerFactory.getLogger("Minitwit");
 
     public static PrometheusMetrics metrics = new PrometheusMetrics();
 
@@ -98,8 +101,6 @@ public class WebApplication {
     private static final String METRIC_TYPE_METRICS = "metrics";
 
     public static void main(String[] args) {
-        System.out.println("Hello Minitwit");
-
         var port = System.getenv("MINITWIT_PORT");
         if (port == null) {
             port = "8080";
@@ -131,8 +132,8 @@ public class WebApplication {
                         res.status()
                 );
             }
-            // TODO: currently doesn't log query parameters or unusual headers
-            System.out.println(LocalDateTime.now() + " - " + req.uri() + " - " + res.status());
+
+            logger.info("t={} status={} method={} {}", LocalDateTime.now(), res.status(), req.requestMethod(), req.uri() );
         });
 
         //before("/metrics", protectEndpoint("Basic asdf"));
@@ -176,7 +177,7 @@ public class WebApplication {
                 return r.handle(request, response);
             } catch (Exception e) {
                 response.status(500);
-                e.printStackTrace();
+                logger.error("Exception happened while processing request", e);
                 return e.toString();
             }
         };
@@ -945,6 +946,7 @@ public class WebApplication {
     };
 
     public static Route serveMetrics = (Request request, Response response) -> {
+        if (true)throw new Exception("Ew");
         return metrics.metrics();
     };
 


### PR DESCRIPTION
Using slf4j because Spark expects it for its own logs

This is the logs after starting the server and accessing /public and a purposefully borked /metrics endpoint that throws a "Ew" exception.
```
[main] INFO spark.staticfiles.StaticFilesConfiguration - StaticResourceHandler configured with folder = /static
[Thread-0] INFO org.eclipse.jetty.util.log - Logging initialized @375ms to org.eclipse.jetty.util.log.Slf4jLog
[Thread-0] INFO spark.embeddedserver.jetty.EmbeddedJettyServer - == Spark has ignited ...
[Thread-0] INFO spark.embeddedserver.jetty.EmbeddedJettyServer - >> Listening on 0.0.0.0:8080
[Thread-0] INFO org.eclipse.jetty.server.Server - jetty-9.4.31.v20200723; built: 2020-07-23T17:57:36.812Z; git: 450ba27947e13e66baa8cd1ce7e85a4461cacc1d; jvm 17.0.2+8-86
[Thread-0] INFO org.eclipse.jetty.server.session - DefaultSessionIdManager workerName=node0
[Thread-0] INFO org.eclipse.jetty.server.session - No SessionScavenger set, using defaults
[Thread-0] INFO org.eclipse.jetty.server.session - node0 Scavenging every 660000ms
[Thread-0] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@12d28054{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
[Thread-0] INFO org.eclipse.jetty.server.Server - Started @533ms
[qtp2054848962-25] WARN org.apache.velocity.deprecation - configuration key 'resource.loader' has been deprecated in favor of 'resource.loaders'
[qtp2054848962-25] WARN org.apache.velocity.deprecation - configuration key 'class.resource.loader.class' has been deprecated in favor of 'resource.loader.class.class'
[qtp2054848962-25] INFO Minitwit - t=2022-04-02T17:47:39.423824295 status=200 method=GET /public
[qtp2054848962-24] ERROR Minitwit - Exception happened while processing request
java.lang.Exception: Ew
	at WebApplication.lambda$static$21(WebApplication.java:950)
	at WebApplication.lambda$catchRoute$3(WebApplication.java:178)
	at spark.RouteImpl$1.handle(RouteImpl.java:72)
	at spark.http.matching.Routes.execute(Routes.java:61)
	at spark.http.matching.MatcherFilter.doFilter(MatcherFilter.java:134)
	at spark.embeddedserver.jetty.JettyHandler.doHandle(JettyHandler.java:50)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1584)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:501)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:556)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:273)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938)
	at java.base/java.lang.Thread.run(Thread.java:833)
[qtp2054848962-24] INFO Minitwit - t=2022-04-02T17:47:49.837462185 status=500 method=GET /metrics
```