### PR TITLE
Add load balancing and second web server

### DIFF
--- a/minitwit/.drone.yml
+++ b/minitwit/.drone.yml
@@ -136,4 +136,4 @@ volumes:
 ---
 
 kind: signature
-hmac: d657a23cd53a8d2be9e2752006a21fa15ff0a353d280d812ae068606e97eac2a
+hmac: 0bf3522a2d5fa04bceabeaf21e82aea1f1d25c63a610bf8ecb570b50489ac08d

--- a/minitwit/.drone.yml
+++ b/minitwit/.drone.yml
@@ -98,13 +98,18 @@ steps:
       from_secret: root_password
     POSTGRES_PASSWORD:
       from_secret: POSTGRES_PASSWORD
-    WEB_HOST:
-      "143.198.249.10"
+    WEB_HOST_1:
+      "164.92.150.233"
+    WEB_HOST_2:
+      "206.189.13.233"
   commands:
   - apk add --no-cache sshpass openssh
-  - sshpass -p "$ROOT_PASSWORD" scp -o StrictHostKeyChecking=no terraform/files/update_image.sh root@$WEB_HOST:/tmp/
-  - sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST chmod +x /tmp/update_image.sh
-  - sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST /tmp/update_image.sh registry.digitalocean.com/minitwit/minitwit-server $DRONE_BUILD_NUMBER $DOCKER_USERNAME $DOCKER_PASSWORD $POSTGRES_PASSWORD
+  - sshpass -p "$ROOT_PASSWORD" scp -o StrictHostKeyChecking=no terraform/files/update_image.sh root@$WEB_HOST_1:/tmp/
+  - sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST_1 chmod +x /tmp/update_image.sh
+  - sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST_1 /tmp/update_image.sh registry.digitalocean.com/minitwit/minitwit-server $DRONE_BUILD_NUMBER $DOCKER_USERNAME $DOCKER_PASSWORD $POSTGRES_PASSWORD
+  - sshpass -p "$ROOT_PASSWORD" scp -o StrictHostKeyChecking=no terraform/files/update_image.sh root@$WEB_HOST_2:/tmp/
+  - sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST_2 chmod +x /tmp/update_image.sh
+  - sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST_2 /tmp/update_image.sh registry.digitalocean.com/minitwit/minitwit-server $DRONE_BUILD_NUMBER $DOCKER_USERNAME $DOCKER_PASSWORD $POSTGRES_PASSWORD
 
 - name: create github release
   image: alpine:3.15.0

--- a/terraform/droplets.tf
+++ b/terraform/droplets.tf
@@ -4,6 +4,7 @@ resource "digitalocean_droplet" "web" {
   name     = "web-${count.index + 1}"
   region   = "ams3"
   size     = "s-1vcpu-1gb"
+  tags     = ["web-lb"]
   ssh_keys = [
     digitalocean_ssh_key.leonora.fingerprint,
     digitalocean_ssh_key.smilla.fingerprint

--- a/terraform/droplets.tf
+++ b/terraform/droplets.tf
@@ -1,10 +1,12 @@
 resource "digitalocean_droplet" "web" {
+  count    = 2
   image    = "ubuntu-18-04-x64"
-  name     = "web-1"
+  name     = "web-${count.index + 1}"
   region   = "ams3"
   size     = "s-1vcpu-1gb"
   ssh_keys = [
-    digitalocean_ssh_key.leonora.fingerprint
+    digitalocean_ssh_key.leonora.fingerprint,
+    digitalocean_ssh_key.smilla.fingerprint
   ]
 
   connection {

--- a/terraform/ips.tf
+++ b/terraform/ips.tf
@@ -1,4 +1,4 @@
 resource "digitalocean_floating_ip" "minitwit-external" {
-  droplet_id = digitalocean_droplet.web.id
-  region     = digitalocean_droplet.web.region
+  droplet_id = digitalocean_droplet.web[0].id
+  region     = digitalocean_droplet.web[0].region
 }

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -1,0 +1,30 @@
+resource "digitalocean_loadbalancer" "lb" {
+  name                     = "lb-1"
+  region                   = "ams3"
+  enable_backend_keepalive = true
+  droplet_tag              = "web-lb"
+
+  forwarding_rule {
+    entry_port      = 80
+    entry_protocol  = "http"
+
+    target_port     = 80
+    target_protocol = "http"
+  }
+
+  sticky_sessions {
+    type               = "cookies"
+    cookie_name        = "DO-LB"
+    cookie_ttl_seconds = 300
+  }
+
+  healthcheck {
+    protocol                 = "http"
+    port                     = 80
+    path                     = "/"
+    check_interval_seconds   = 10
+    response_timeout_seconds = 5
+    unhealthy_threshold      = 3
+    healthy_threshold        = 5
+  }
+}


### PR DESCRIPTION
Closes #132 

This PR adds a second web server and a load balancer to split requests between the two web servers.

The new load balancer IP (which the simulator should be using): http://143.198.248.210/

The servers are already up and running, this PR just adds the terraform files. However the web-2 server needs to be added to the Drone pipeline (and deployed to) before it will be online and taking requests.