### PR TITLE
Add deploy script for rolling updates

### DIFF
--- a/minitwit/.drone.yml
+++ b/minitwit/.drone.yml
@@ -99,12 +99,10 @@ steps:
     POSTGRES_PASSWORD:
       from_secret: POSTGRES_PASSWORD
     WEB_HOST:
-      "143.198.249.10"
+      "143.198.249.10 206.189.13.233"
   commands:
   - apk add --no-cache sshpass openssh
-  - sshpass -p "$ROOT_PASSWORD" scp -o StrictHostKeyChecking=no terraform/files/update_image.sh root@$WEB_HOST:/tmp/
-  - sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST chmod +x /tmp/update_image.sh
-  - sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST /tmp/update_image.sh registry.digitalocean.com/minitwit/minitwit-server $DRONE_BUILD_NUMBER $DOCKER_USERNAME $DOCKER_PASSWORD $POSTGRES_PASSWORD
+  - ./terraform/deploy.sh $ROOT_PASSWORD $WEB_HOSTS $DRONE_BUILD_NUMBER $DOCKER_USERNAME $DOCKER_PASSWORD $POSTGRES_PASSWORD
 
 - name: create github release
   image: alpine:3.15.0

--- a/minitwit/src/main/java/WebApplication.java
+++ b/minitwit/src/main/java/WebApplication.java
@@ -79,6 +79,9 @@ public class WebApplication {
         public static final String SIM_LATEST = "/latest";
         public static final String SIM_MSGS_USR = "/msgs/:username";
         public static final String SIM_FLLWS = "/fllws/:username";
+
+
+        public static final String STATUS = "/status";
     }
 
     public static int PER_PAGE = 30;
@@ -148,6 +151,8 @@ public class WebApplication {
         //before("/metrics", protectEndpoint("Basic asdf"));
         get("/metrics", catchRoute(WebApplication.serveMetrics));
         get("/metrics/stats", catchRoute(WebApplication.serveStats), gson::toJson);
+
+        get(URLS.STATUS, catchRoute(WebApplication.serveStatus));
 
         get(URLS.PUBLIC_TIMELINE, catchRoute(WebApplication.servePublicTimelinePage));
         get(URLS.REGISTER, catchRoute(WebApplication.serveRegisterPage));
@@ -1056,5 +1061,11 @@ public class WebApplication {
                 Map.entry("followerStats", followers),
                 Map.entry("followingStats", following)
         );
+    };
+
+    public static Route serveStatus = (Request request, Response response) -> {
+        // Return status code 200 and OK if everything is fine, consider returning something like status 503 Service
+        // Unavailable if the server is unable to process requests.
+        return "OK";
     };
 }

--- a/terraform/files/deploy.sh
+++ b/terraform/files/deploy.sh
@@ -1,0 +1,46 @@
+ROOT_PASSWORD=$1
+WEB_HOSTS=$2
+DRONE_BUILD_NUMBER=$3
+DOCKER_USERNAME=$4
+DOCKER_PASSWORD=$5
+POSTGRES_PASSWORD=$6
+
+maxtries=10
+delay=5
+
+for WEB_HOST in $WEB_HOSTS
+do
+    echo "Updating $WEB_HOST..."
+    sshpass -p "$ROOT_PASSWORD" scp -o StrictHostKeyChecking=no terraform/files/update_image.sh root@$WEB_HOST:/tmp/
+    sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST chmod +x /tmp/update_image.sh
+    sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST \
+        /tmp/update_image.sh \
+            registry.digitalocean.com/minitwit/minitwit-server \
+            $DRONE_BUILD_NUMBER \
+            $DOCKER_USERNAME \
+            $DOCKER_PASSWORD \
+            $POSTGRES_PASSWORD
+
+    echo "Testing server"
+    r="NO"
+    tries=0
+    while [ $r != "OK" ] && [ $tries -lt $maxtries]
+    do
+        sleep $delay
+        echo Testing...
+        # If $r is empty then the test will fail, so echo NO into it if server is down
+        r=$(curl -s http://127.0.0.1:8080/status || echo "NO")
+    done
+
+    if [ $tries -eq $maxtries ]
+    then
+        echo "Service on $WEB_HOST is not available after $tries tries!"
+        exit 1
+    else
+        echo "Done updating $WEB_HOST..."
+    fi
+done
+
+echo "Updated all servers"
+
+


### PR DESCRIPTION
Closes #145 
Will loop over a list of hosts and test if they come alive before moving on.
Also adds a status endpoint that in the future could allow testing if it is connected to the database.

On failure it will stop updating without attempting to roll back successfully updated hosts.