### PR TITLE
Add deploy script for rolling updates

### DIFF
--- a/minitwit/.drone.yml
+++ b/minitwit/.drone.yml
@@ -130,4 +130,4 @@ volumes:
 ---
 
 kind: signature
-hmac: 0bf3522a2d5fa04bceabeaf21e82aea1f1d25c63a610bf8ecb570b50489ac08d
+hmac: 665c16bfb4cabbf71d879d244823f63888c469b2d6eb2cb046fda9bb76a90f94

--- a/minitwit/.drone.yml
+++ b/minitwit/.drone.yml
@@ -102,6 +102,7 @@ steps:
       "164.92.150.233 206.189.13.233"
   commands:
   - apk add --no-cache sshpass openssh
+  - chmod +x ./terraform/deploy.sh
   - ./terraform/deploy.sh $ROOT_PASSWORD $WEB_HOSTS $DRONE_BUILD_NUMBER $DOCKER_USERNAME $DOCKER_PASSWORD $POSTGRES_PASSWORD
 
 - name: create github release

--- a/minitwit/.drone.yml
+++ b/minitwit/.drone.yml
@@ -130,4 +130,4 @@ volumes:
 ---
 
 kind: signature
-hmac: 665c16bfb4cabbf71d879d244823f63888c469b2d6eb2cb046fda9bb76a90f94
+hmac: 8d0bb4018bab1b0fcdeac5750d8312f59fa3f4399ff1ee133b305d4c30bf5613

--- a/minitwit/.drone.yml
+++ b/minitwit/.drone.yml
@@ -99,12 +99,10 @@ steps:
     POSTGRES_PASSWORD:
       from_secret: POSTGRES_PASSWORD
     WEB_HOST:
-      "143.198.249.10"
+      "143.198.249.10 206.189.13.233"
   commands:
   - apk add --no-cache sshpass openssh
-  - sshpass -p "$ROOT_PASSWORD" scp -o StrictHostKeyChecking=no terraform/files/update_image.sh root@$WEB_HOST:/tmp/
-  - sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST chmod +x /tmp/update_image.sh
-  - sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST /tmp/update_image.sh registry.digitalocean.com/minitwit/minitwit-server $DRONE_BUILD_NUMBER $DOCKER_USERNAME $DOCKER_PASSWORD $POSTGRES_PASSWORD
+  - ./terraform/deploy.sh $ROOT_PASSWORD $WEB_HOSTS $DRONE_BUILD_NUMBER $DOCKER_USERNAME $DOCKER_PASSWORD $POSTGRES_PASSWORD
 
 - name: create github release
   image: alpine:3.15.0

--- a/minitwit/.drone.yml
+++ b/minitwit/.drone.yml
@@ -102,8 +102,8 @@ steps:
       "164.92.150.233 206.189.13.233"
   commands:
   - apk add --no-cache sshpass openssh
-  - chmod +x ./terraform/deploy.sh
-  - ./terraform/deploy.sh $ROOT_PASSWORD $WEB_HOSTS $DRONE_BUILD_NUMBER $DOCKER_USERNAME $DOCKER_PASSWORD $POSTGRES_PASSWORD
+  - chmod +x ./terraform/files/deploy.sh
+  - ./terraform/files/deploy.sh $ROOT_PASSWORD $WEB_HOSTS $DRONE_BUILD_NUMBER $DOCKER_USERNAME $DOCKER_PASSWORD $POSTGRES_PASSWORD
 
 - name: create github release
   image: alpine:3.15.0

--- a/minitwit/.drone.yml
+++ b/minitwit/.drone.yml
@@ -98,7 +98,7 @@ steps:
       from_secret: root_password
     POSTGRES_PASSWORD:
       from_secret: POSTGRES_PASSWORD
-    WEB_HOST:
+    WEB_HOSTS:
       "164.92.150.233 206.189.13.233"
   commands:
   - apk add --no-cache sshpass openssh

--- a/minitwit/src/main/java/WebApplication.java
+++ b/minitwit/src/main/java/WebApplication.java
@@ -79,6 +79,9 @@ public class WebApplication {
         public static final String SIM_LATEST = "/latest";
         public static final String SIM_MSGS_USR = "/msgs/:username";
         public static final String SIM_FLLWS = "/fllws/:username";
+
+
+        public static final String STATUS = "/status";
     }
 
     public static int PER_PAGE = 30;
@@ -148,6 +151,8 @@ public class WebApplication {
         //before("/metrics", protectEndpoint("Basic asdf"));
         get("/metrics", catchRoute(WebApplication.serveMetrics));
         get("/metrics/stats", catchRoute(WebApplication.serveStats), gson::toJson);
+
+        get(URLS.STATUS, catchRoute(WebApplication.serveStatus));
 
         get(URLS.PUBLIC_TIMELINE, catchRoute(WebApplication.servePublicTimelinePage));
         get(URLS.REGISTER, catchRoute(WebApplication.serveRegisterPage));
@@ -1056,5 +1061,11 @@ public class WebApplication {
                 Map.entry("followerStats", followers),
                 Map.entry("followingStats", following)
         );
+    };
+
+    public static Route serveStatus = (Request request, Response response) -> {
+        // Return status code 200 and OK if everything is fine, consider returning something like status 503 Service
+        // Unavailable if the server is unable to process requests.
+        return "OK";
     };
 }

--- a/terraform/files/deploy.sh
+++ b/terraform/files/deploy.sh
@@ -1,0 +1,46 @@
+ROOT_PASSWORD=$1
+WEB_HOSTS=$2
+DRONE_BUILD_NUMBER=$3
+DOCKER_USERNAME=$4
+DOCKER_PASSWORD=$5
+POSTGRES_PASSWORD=$6
+
+maxtries=10
+delay=5
+
+for WEB_HOST in $WEB_HOSTS
+do
+    echo "Updating $WEB_HOST..."
+    sshpass -p "$ROOT_PASSWORD" scp -o StrictHostKeyChecking=no terraform/files/update_image.sh root@$WEB_HOST:/tmp/
+    sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST chmod +x /tmp/update_image.sh
+    sshpass -p "$ROOT_PASSWORD" ssh -o StrictHostKeyChecking=no root@$WEB_HOST \
+        /tmp/update_image.sh \
+            registry.digitalocean.com/minitwit/minitwit-server \
+            $DRONE_BUILD_NUMBER \
+            $DOCKER_USERNAME \
+            $DOCKER_PASSWORD \
+            $POSTGRES_PASSWORD
+
+    echo "Testing server"
+    r="NO"
+    tries=0
+    while [ $r != "OK" ] && [ $tries -lt $maxtries]
+    do
+        sleep $delay
+        echo Testing...
+        # If $r is empty then the test will fail, so echo NO into it if server is down
+        r=$(curl -s http://127.0.0.1:8080/status || echo "NO")
+    done
+
+    if [ $tries -eq $maxtries ]
+    then
+        echo "Service on $WEB_HOST is not available after $tries tries!"
+        exit 1
+    else
+        echo "Done updating $WEB_HOST..."
+    fi
+done
+
+echo "Updated all servers"
+
+


### PR DESCRIPTION
Closes #145 
Will loop over a list of hosts and test if they come alive before moving on.
Also adds a status endpoint that in the future could allow testing if it is connected to the database.

On failure it will stop updating without attempting to roll back successfully updated hosts.